### PR TITLE
Fix alpha value scheme C

### DIFF
--- a/src/pineko/theory.py
+++ b/src/pineko/theory.py
@@ -394,7 +394,9 @@ class TheoryBuilder:
         q2_grid = operators["Q2grid"].keys()
         # PineAPPL wants alpha_s = 4*pi*a_s
         # remember that we already accounted for xif in the opcard generation
-        alphas_values = [4.0 * np.pi * astrong.a_s(xir * xir * Q2) for Q2 in q2_grid]
+        alphas_values = [
+            4.0 * np.pi * astrong.a_s(xir * xir * Q2 / xif / xif) for Q2 in q2_grid
+        ]
         # Obtain the assumptions hash
         assumptions = theory_card.construct_assumptions(tcard)
         # do it!


### PR DESCRIPTION
After several discussions we agreed on the fact that for the scheme C of scale variations we need to evaluate alpha_s at the process scale and not at the factorization scale (assuming no renormalization scale variations of course). 

This is equivalent to a previous commit (65682936b4e64aeb9d84ad87a062dc12dcee867c)