### PR TITLE
Fix compatibility to eko 0.11

### DIFF
--- a/src/pineko/check.py
+++ b/src/pineko/check.py
@@ -1,4 +1,6 @@
 """Tools to check compatibility of EKO and grid."""
+import tarfile
+
 import numpy as np
 import pineappl
 
@@ -198,3 +200,15 @@ def contains_ren(grid, max_as, max_al):
     if not order_al_is_present:
         sv_al_present = True
     return sv_as_present, sv_al_present
+
+
+def check_eko_is_legacy(eko_name):
+    """Check if the eko tar file is a legacy eko file."""
+    tar = tarfile.open(eko_name)
+    file_names = [file.name for file in tar.getmembers()]
+    legacy_patterns = ["operators.npy.lz4", "operator_errors.npy.lz4"]
+    for name in file_names:
+        for pattern in legacy_patterns:
+            if pattern in name:
+                return True
+    return False

--- a/src/pineko/theory.py
+++ b/src/pineko/theory.py
@@ -6,6 +6,7 @@ together with other theory ingredients (such as C-factors) are often
 commonly referred to as 'theory'.
 """
 import logging
+import tarfile
 import time
 
 import eko
@@ -397,7 +398,10 @@ class TheoryBuilder:
         # q2_grid = ocard["Q2grid"]
 
         # loading ekos
-        operators = eko.output.legacy.load_tar(eko_filename)
+        if check.check_eko_is_legacy(eko_filename):
+            operators = eko.output.legacy.load_tar(eko_filename)
+        else:
+            operators = eko.output.EKO.load(eko_filename)
         muf2_grid = operators.Q2grid
         # PineAPPL wants alpha_s = 4*pi*a_s
         # remember that we already accounted for xif in the opcard generation


### PR DESCRIPTION
We want to have `pineko` fully compatible with `eko==0.11`. For the moment this is the list of things to be done:

- [ ] Check `eko` tar file is legacy before loading and use the correct method
- [ ] Dump the eko in the correct way (using the new method)
- [ ] Fix the `inputpids` and `targetpids` entries of the opcard (most likely `rotations.inputpids` and `rotations.targetpids` should be transformation matrices).