### PR TITLE
Scope op card template in theory

### DIFF
--- a/benchmarks/bench_cli.py
+++ b/benchmarks/bench_cli.py
@@ -57,7 +57,9 @@ def benchmark_opcard_cli(tmp_path, test_files):
     grid_path = pathlib.Path(
         test_files / "data/grids/208/LHCB_DY_13TEV_DIMUON.pineappl.lz4"
     )
-    default_card_path = pathlib.Path(test_files / "data/operator_cards/_template.yaml")
+    default_card_path = pathlib.Path(
+        test_files / "data/operator_cards/208/_template.yaml"
+    )
     thcard_path = pathlib.Path(test_files / "data" / "theory_cards" / "208.yaml")
     target_path = pathlib.Path(tmp_path / "test_ope_card.yaml")
     runner = CliRunner()

--- a/benchmarks/bench_evolve.py
+++ b/benchmarks/bench_evolve.py
@@ -16,7 +16,7 @@ import pineko.theory_card
 
 def benchmark_write_operator_card_from_file(tmp_path, test_files, test_configs):
     pine_path = test_files / "data/grids/208/HERA_CC_318GEV_EM_SIGMARED.pineappl.lz4"
-    default_path = test_files / "data/operator_cards/_template.yaml"
+    default_path = test_files / "data/operator_cards/208/_template.yaml"
     target_path = pathlib.Path(tmp_path / "test_operator.yaml")
 
     # Load the theory card
@@ -44,7 +44,7 @@ def benchmark_write_operator_card_from_file(tmp_path, test_files, test_configs):
 
 def benchmark_dglap(tmp_path, test_files, test_configs):
     pine_path = test_files / "data/grids/208/HERA_CC_318GEV_EM_SIGMARED.pineappl.lz4"
-    default_path = test_files / "data/operator_cards/_template.yaml"
+    default_path = test_files / "data/operator_cards/208/_template.yaml"
     target_path = pathlib.Path(tmp_path / "test_operator.yaml")
 
     theory_id = 208

--- a/docs/source/overview/prerequisites.rst
+++ b/docs/source/overview/prerequisites.rst
@@ -18,7 +18,7 @@ This is a standard example:
   ymldb = "data/yamldb"
   grids = "data/grids"
   theory_cards = "data/theory_cards"
-  operator_card_template = "data/operator_cards/_template.yaml"
+  operator_card_template_name = "_template.yaml"
   # outputs
   operator_cards = "data/operator_cards"
   ekos = "data/ekos"
@@ -57,7 +57,7 @@ For more details about theory runcards you can look to https://eko.readthedocs.i
 Default Operator Card
 ---------------------
 
-You need to provide a default operator card for |EKO| [4]_.
+You need to provide a default operator card for |EKO| for each theory you want to use [4]_.
 [**DEBUG**: Look at the respective *load.sh* script to load from dom.]
 An example is the following:
 

--- a/pineko.debug.toml
+++ b/pineko.debug.toml
@@ -3,7 +3,7 @@
 ymldb = "data/ymldb"
 grids = "data/grids"
 theory_cards = "data/theory_cards"
-operator_card_template = "data/operator_cards/_template.yaml"
+operator_card_template_name = "_template.yaml"
 # outputs
 operator_cards = "data/operator_cards"
 ekos = "data/ekos"

--- a/src/pineko/configs.py
+++ b/src/pineko/configs.py
@@ -51,7 +51,6 @@ def enhance_paths(configs_):
         "ymldb",
         "operator_cards",
         "grids",
-        "operator_card_template",
         "theory_cards",
         "fktables",
         "ekos",

--- a/src/pineko/theory.py
+++ b/src/pineko/theory.py
@@ -225,7 +225,7 @@ class TheoryBuilder:
                 return
         _x_grid, q2_grid = evolve.write_operator_card_from_file(
             grid,
-            configs.configs["paths"]["operator_card_template"],
+            self.operator_cards_path / configs.configs["paths"]["operator_card_template_name"],
             opcard_path,
             xif,
             tcard_path,

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -11,7 +11,6 @@ def test_enhance_paths():
         "paths": {
             "ymldb": pathlib.Path(""),
             "grids": pathlib.Path(""),
-            "operator_card_template": pathlib.Path(""),
             "theory_cards": pathlib.Path(""),
             "fktables": pathlib.Path(""),
             "ekos": pathlib.Path(""),
@@ -38,7 +37,6 @@ def test_default():
             "ymldb": pathlib.Path(""),
             "grids": pathlib.Path(""),
             "operator_cards": pathlib.Path("my/ope/cards/"),
-            "operator_card_template": pathlib.Path(""),
             "theory_cards": pathlib.Path(""),
             "fktables": pathlib.Path(""),
             "ekos": pathlib.Path(""),


### PR DESCRIPTION
Closes #47 

if we agree on the strategy then I should
- [x] update the doc (here and in https://github.com/NNPDF/pineline - note that we have a slight duplication issue)
- [ ] add some tests

note that users now have to provide in addition to the external grids also the template operator card (could be also addressed in #50 )

cc @scarlehoff 