### PR TITLE
Add a warning when using truncated and ev_op_iterations > 1

### DIFF
--- a/src/pineko/evolve.py
+++ b/src/pineko/evolve.py
@@ -1,5 +1,6 @@
 """Tools related to evolution/eko."""
 import copy
+import logging
 import os
 import pathlib
 
@@ -16,6 +17,8 @@ from eko.matchings import Atlas, nf_default
 from eko.quantities import heavy_quarks
 
 from . import check, comparator, ekompatibility, version
+
+logger = logging.getLogger(__name__)
 
 
 def sv_scheme(tcard):
@@ -132,6 +135,15 @@ def write_operator_card(pineappl_grid, default_card, card_path, tcard):
         x_grid = np.append(x_grid, 1.0)
         operators_card["configs"]["interpolation_polynomial_degree"] = 1
         operators_card["xgrid"] = x_grid.tolist()
+
+    # Some safety checks
+    if (
+        operators_card["configs"]["evolution_method"] == "truncated"
+        and operators_card["configs"]["ev_op_iterations"] > 1
+    ):
+        logger.warning(
+            "Warning! You are setting evolution_method=truncated with ev_op_iterations>1, are you sure that's what you want? "
+        )
 
     with open(card_path, "w", encoding="UTF-8") as f:
         yaml.safe_dump(operators_card, f)


### PR DESCRIPTION
As the title says. It is a warning and not an error because it is not necessarily wrong, but it is very likely that this is not what the user wanted (and it will generate results that do look wrong).