### PR TITLE
Rotate the eko back to save disk space

### DIFF
--- a/src/pineko/evolve.py
+++ b/src/pineko/evolve.py
@@ -202,16 +202,15 @@ def evolve_grid(
     # rotate the targetgrid
     if "integrability_version" in grid.key_values():
         x_grid = np.append(x_grid, 1.0)
-    new_operators = copy.deepcopy(operators)
     eko.io.manipulate.xgrid_reshape(
-        new_operators, targetgrid=eko.interpolation.XGrid(x_grid)
+        operators, targetgrid=eko.interpolation.XGrid(x_grid)
     )
-    check.check_grid_and_eko_compatible(grid, new_operators, xif, max_as, max_al)
+    check.check_grid_and_eko_compatible(grid, operators, xif, max_as, max_al)
     # rotate to evolution (if doable and necessary)
-    if np.allclose(new_operators.bases.inputpids, br.flavor_basis_pids):
-        eko.io.manipulate.to_evol(new_operators)
+    if np.allclose(operators.bases.inputpids, br.flavor_basis_pids):
+        eko.io.manipulate.to_evol(operators)
     # Here we are checking if the EKO contains the rotation matrix (flavor to evol)
-    elif not np.allclose(new_operators.bases.inputpids, br.rotate_flavor_to_evolution):
+    elif not np.allclose(operators.bases.inputpids, br.rotate_flavor_to_evolution):
         raise ValueError("The EKO is neither in flavor nor in evolution basis.")
     # PineAPPL wants alpha_s = 4*pi*a_s
     # remember that we already accounted for xif in the opcard generation
@@ -240,15 +239,13 @@ def evolve_grid(
     ]
     # We need to use ekompatibility in order to pass a dictionary to pineappl
     fktable = grid.evolve(
-        ekompatibility.pineappl_layout(new_operators),
+        ekompatibility.pineappl_layout(operators),
         xir * xir * mur2_grid,
         alphas_values,
         "evol",
         order_mask=order_mask,
         xi=(xir, xif),
     )
-    # Save only the original operator to save disk space
-    del new_operators
     rich.print(f"Optimizing for {assumptions}")
     fktable.optimize(assumptions)
     fktable.set_key_value("eko_version", operators.metadata.version)

--- a/src/pineko/evolve.py
+++ b/src/pineko/evolve.py
@@ -246,6 +246,10 @@ def evolve_grid(
         order_mask=order_mask,
         xi=(xir, xif),
     )
+    # Rotate again the eko to save disk space
+    eko.io.manipulate.xgrid_reshape(
+        operators, targetgrid=opcard.xgrid
+    )
     rich.print(f"Optimizing for {assumptions}")
     fktable.optimize(assumptions)
     fktable.set_key_value("eko_version", operators.metadata.version)

--- a/src/pineko/evolve.py
+++ b/src/pineko/evolve.py
@@ -202,6 +202,7 @@ def evolve_grid(
     # rotate the targetgrid
     if "integrability_version" in grid.key_values():
         x_grid = np.append(x_grid, 1.0)
+    orignal_operators = copy.deepcopy(operators)
     eko.io.manipulate.xgrid_reshape(
         operators, targetgrid=eko.interpolation.XGrid(x_grid)
     )
@@ -246,10 +247,8 @@ def evolve_grid(
         order_mask=order_mask,
         xi=(xir, xif),
     )
-    # Rotate again the eko to save disk space
-    eko.io.manipulate.xgrid_reshape(
-        operators, targetgrid=opcard.xgrid
-    )
+    # Save only the original operator to save disk space
+    operators = orignal_operators
     rich.print(f"Optimizing for {assumptions}")
     fktable.optimize(assumptions)
     fktable.set_key_value("eko_version", operators.metadata.version)

--- a/src/pineko/evolve.py
+++ b/src/pineko/evolve.py
@@ -202,16 +202,16 @@ def evolve_grid(
     # rotate the targetgrid
     if "integrability_version" in grid.key_values():
         x_grid = np.append(x_grid, 1.0)
-    orignal_operators = copy.deepcopy(operators)
+    new_operators = copy.deepcopy(operators)
     eko.io.manipulate.xgrid_reshape(
-        operators, targetgrid=eko.interpolation.XGrid(x_grid)
+        new_operators, targetgrid=eko.interpolation.XGrid(x_grid)
     )
-    check.check_grid_and_eko_compatible(grid, operators, xif, max_as, max_al)
+    check.check_grid_and_eko_compatible(grid, new_operators, xif, max_as, max_al)
     # rotate to evolution (if doable and necessary)
-    if np.allclose(operators.bases.inputpids, br.flavor_basis_pids):
-        eko.io.manipulate.to_evol(operators)
+    if np.allclose(new_operators.bases.inputpids, br.flavor_basis_pids):
+        eko.io.manipulate.to_evol(new_operators)
     # Here we are checking if the EKO contains the rotation matrix (flavor to evol)
-    elif not np.allclose(operators.bases.inputpids, br.rotate_flavor_to_evolution):
+    elif not np.allclose(new_operators.bases.inputpids, br.rotate_flavor_to_evolution):
         raise ValueError("The EKO is neither in flavor nor in evolution basis.")
     # PineAPPL wants alpha_s = 4*pi*a_s
     # remember that we already accounted for xif in the opcard generation
@@ -240,7 +240,7 @@ def evolve_grid(
     ]
     # We need to use ekompatibility in order to pass a dictionary to pineappl
     fktable = grid.evolve(
-        ekompatibility.pineappl_layout(operators),
+        ekompatibility.pineappl_layout(new_operators),
         xir * xir * mur2_grid,
         alphas_values,
         "evol",
@@ -248,7 +248,7 @@ def evolve_grid(
         xi=(xir, xif),
     )
     # Save only the original operator to save disk space
-    operators = orignal_operators
+    del new_operators
     rich.print(f"Optimizing for {assumptions}")
     fktable.optimize(assumptions)
     fktable.set_key_value("eko_version", operators.metadata.version)

--- a/src/pineko/theory.py
+++ b/src/pineko/theory.py
@@ -395,8 +395,11 @@ class TheoryBuilder:
         if sv_method is None:
             if not np.isclose(xif, 1.0):
                 check_scvar_evolve(grid, max_as, max_al, check.Scale.FACT)
-        # loading ekos
+        # loading ekos to produce a tmp copy
         with eko.EKO.edit(eko_filename) as operators:
+            eko_tmp_path = operators.paths.root.parent / "eko-tmp"
+            operators.deepcopy(eko_tmp_path)
+        with eko.EKO.edit(eko_tmp_path) as operators:
             # Obtain the assumptions hash
             assumptions = theory_card.construct_assumptions(tcard)
             # do it!
@@ -430,6 +433,9 @@ class TheoryBuilder:
                 assumptions=assumptions,
                 comparison_pdf=pdf,
             )
+        # Remove tmp ekos
+        eko_tmp_path.unlink()
+
         logger.info(
             "Finished computation of %s - took %f s",
             name,

--- a/src/pineko/theory.py
+++ b/src/pineko/theory.py
@@ -396,7 +396,7 @@ class TheoryBuilder:
             if not np.isclose(xif, 1.0):
                 check_scvar_evolve(grid, max_as, max_al, check.Scale.FACT)
         # loading ekos to produce a tmp copy
-        with eko.EKO.edit(eko_filename) as operators:
+        with eko.EKO.read(eko_filename) as operators:
             eko_tmp_path = operators.paths.root.parent / "eko-tmp.tar"
             operators.deepcopy(eko_tmp_path)
         with eko.EKO.edit(eko_tmp_path) as operators:

--- a/src/pineko/theory.py
+++ b/src/pineko/theory.py
@@ -397,7 +397,7 @@ class TheoryBuilder:
                 check_scvar_evolve(grid, max_as, max_al, check.Scale.FACT)
         # loading ekos to produce a tmp copy
         with eko.EKO.edit(eko_filename) as operators:
-            eko_tmp_path = operators.paths.root.parent / "eko-tmp"
+            eko_tmp_path = operators.paths.root.parent / "eko-tmp.tar"
             operators.deepcopy(eko_tmp_path)
         with eko.EKO.edit(eko_tmp_path) as operators:
             # Obtain the assumptions hash


### PR DESCRIPTION
We want to rotate the eko back to the usual grid of 50 points to save disk space. In fact, as noticed by @giacomomagni, depending on the dataset, there is a factor up to ~30 in size between the original eko and the eko after the rotation (for the jets dataset the factor is ~24). 