### PR TITLE
Automatise numerical FONLL

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -8,8 +8,9 @@ SPHINXBUILD   = sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
 
-PINEKODIR = ../src/eko
+PINEKODIR = ../src/pineko
 PINEKOOUT = $(SOURCEDIR)/modules/pineko
+TODOOUTFILE = ./source/code_todos.rst
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -41,4 +42,4 @@ todos:
 	python generate_code_todos.py "$(PINEKODIR)" "$(TODOOUTFILE)"
 
 clean-todos:
-	rm "$(TODOOUTFILE)"
+	rm -f "$(TODOOUTFILE)"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,7 +23,9 @@
     :hidden:
 
     theory/fktables
+    theory/fonll
     theory/scalevar
+    theory/kfactors
 
 
     zzz-refs

--- a/docs/source/overview/prerequisites.rst
+++ b/docs/source/overview/prerequisites.rst
@@ -58,9 +58,7 @@ Default Operator Card
 ---------------------
 
 You need to provide a default operator card for |EKO| for each theory you want to use.
-An example is the following:
-
-::
+An example is the following::
 
   configs:
     evolution_method: truncated
@@ -99,7 +97,6 @@ An example is the following:
     skip_non_singlet: false
     skip_singlet: false
 
-::
 
 For more details about what is needed inside an operator card please refer to https://eko.readthedocs.io/en/latest/code/IO.html
 under the section **Operator Runcard**. Note that the actual operator cards for each FK table will be
@@ -109,23 +106,17 @@ Grids
 -----
 
 *pineko* does **NOT** compute grids, which are instead expected input to *pineko*.
-There are typically two ways to obtain grids: computing them from scratch with `runcards <https://github.com/NNPDF/pinecards/>`_
-or reusing existing ones.
+There are typically two ways to obtain grids:
 
-Generate new Grids with *rr*
-""""""""""""""""""""""""""""
+1. computing them from scratch with
+   `pinefarm <https://github.com/NNPDF/pinefarm/>`_ (and `pinecards <https://github.com/NNPDF/pinecards/>`_).
 
-You need to run *rr* with a given theory runcard and put the generated grid file with the same name
-inside the *paths.grids/theory_id* folder. The name has to match the *ymldb* which is the case by default.
+2. You can reuse the grids from a different theory by running::
 
-Inherit Grids from Existing Theory
-""""""""""""""""""""""""""""""""""
+    pineko theory inherit-grids SOURCE_THEORY_ID TARGET_THEORY_ID DATASET1 DATASET2 ...
 
-You can reuse the grids from a different theory by running::
-
-  pineko theory inherit-grids SOURCE_THEORY_ID TARGET_THEORY_ID DATASET1 DATASET2 ...
-
-The relation between the source theory and the target theory is non-trivial [4]_.
+  The relation between the source theory and the target theory is non-trivial
+  (e.g. they may differ by scale variations, different DIS settings, etc)
 
 
 Notes
@@ -134,5 +125,3 @@ Notes
 .. [2] this is to be replaced by the new CommonData format implemented by NNPDF
 
 .. [3] this is to be replaced by a binding to the NNPDF theory objects
-
-.. [4] examples being scale variations, different evolution settings, etc.

--- a/docs/source/overview/running.rst
+++ b/docs/source/overview/running.rst
@@ -68,7 +68,7 @@ in the final step.
 There are 2 workflows possible, one in which all the steps are performed individually
 and one that is more automatized.
 
-The automatize workflows always assumes that |FONLL| is performed both for
+The automatized workflows always assumes that |FONLL| is performed both for
 charm and bottom effects.
 
 The manual procedure works as follow:

--- a/docs/source/overview/running.rst
+++ b/docs/source/overview/running.rst
@@ -122,7 +122,7 @@ In this case the workflows is:
       pineko fonll_ekos THEORY_ID DATASET1 DATASET2 ...
 
     Note: this is usually an expensive operation as multiple ekos are run sequentially.
-    Depending on the resources that you have available it might be more convinient
+    Depending on the resources that you have available it might be more convenient
     to call the command separately for each DATASET.
 
   4. Generate the final |FONLL| FK table directly running::

--- a/docs/source/overview/running.rst
+++ b/docs/source/overview/running.rst
@@ -1,4 +1,3 @@
-################
 Running `pineko`
 ################
 
@@ -27,8 +26,6 @@ This is a two step process:
 
     pineko theory ekos THEORY_ID DATASET1 DATASET2 ...
 
-
-
 Inherit |EKO| or grids from Existing Theory
 """""""""""""""""""""""""""""""""""""""""""
 
@@ -40,7 +37,8 @@ You can reuse the grid from a different theory by running::
 
   pineko theory inherit-grids SOURCE_THEORY_ID TARGET_THEORY_ID DATASET1 DATASET2 ...
 
-The relation between the source theory and the target theory is non-trivial [5]_.
+The relation between the source theory and the target theory is non-trivial
+(e.g. they may differ by scale variations, different DIS settings, etc).
 
 Generating the FK Table
 -----------------------
@@ -57,146 +55,43 @@ Note that you can also convolute a single grid with a single eko (obtaining a si
 If necessary it is possible to specify the values of the *renormalization* and *factorization* scale variations with
 the options ``--xir`` and ``--xif``.
 
-
-Generating FONLL FK Tables
---------------------------
-
-In order to generate FK tables with |FONLL| the different flavor schemes
-need to be evolved separately and joined together in a single FK table only
-in the final step.
-
-There are 2 workflows possible, one in which all the steps are performed individually
-and one that is more automatized.
-
-The automatized workflows always assumes that |FONLL| is performed both for
-charm and bottom effects.
-
-The manual procedure works as follow:
-
-  1. Generate 7 theories for all the different flavor patches with command::
-
-      pineko fonll_tcards THEORY_ID
-
-    The different flavor patches are named following the convention:
-
-      * ``<THEORY_ID>00`` : |FFNS| :math:`n_f=3`
-      * ``<THEORY_ID>01`` : |FFN0| :math:`n_f=3`
-      * ``<THEORY_ID>02`` : massless component of |FFNS| :math:`n_f=4`
-      * ``<THEORY_ID>03`` : massive component of |FFNS| :math:`n_f=4`
-      * ``<THEORY_ID>04`` : |FFN0| :math:`n_f=4`
-      * ``<THEORY_ID>05`` : massless component of |FFNS| :math:`n_f=5`
-      * ``<THEORY_ID>06`` : massive component of |FFNS| :math:`n_f=5`
-
-    where for |FFNS| :math:`n_f=4,5` massive and massless parts are split to
-    allow for a damping option.
-
-  2. Generate the grids corresponding to all the 7 theories with the external program.
-
-  3. Generate the operator cards for each theory with the normal command listed above.
-     Note that, in principle, only 3 ekos are needed, as there are only 3 different :math:`n_f` patches.
-     So you might speed up the procedure taking advantage of inherit-ekos.
-
-  4. Generate the ekos for each theory with the normal command listed above.
-
-  5. Generate the FK tables each of the 7 theories with the normal command listed above.
-
-  6. Combine the various FK tables into a single file, using the command::
-
-      pineko combine_fonll THEORY_ID DATASET --FFNS3 THEORY_ID00 --FFN03 THEORY_ID01 --FFNS4til THEORY_ID02 --FFNS4bar THEORY_ID03 --FFN04 THEORY_ID04 --FFNS5til THEORY_ID05 --FFNS5bar THEORY_ID06
-
-    where the first 3 theories are needed to perform |FONLL| on charm effects,
-    while the last 4 are needed to include also bottom effects.
-
-The automatized procedure can be faster, but it might be less flexible.
-In this case the workflows is:
-
-  1. Generate 7 theories for all the different flavor patches with the command::
-
-      pineko fonll_tcards THEORY_ID
-
-    See above for the intermediate theories naming convention.
-
-  2. Generate the grids corresponding to all the 7 theories with the external program.
-
-  3. Generate the three ekos, one for each :math:`n_f`, and inherit the others running:
-
-      pineko fonll_ekos THEORY_ID DATASET1 DATASET2 ...
-
-    Note: this is usually an expensive operation as multiple ekos are run sequentially.
-    Depending on the resources that you have available it might be more convenient
-    to call the command separately for each DATASET.
-
-  4. Generate the final |FONLL| FK table directly running::
-
-      pineko fonll_fks THEORY_ID DATASET1 DATASET2 ...
-
-
 Other functionalities
 ---------------------
 
 Other than the fundamental functions that have been described so far, *pineko* has a few
-handy utility functions.
+handy utility functions:
+
+- applying the :doc:`FONLL prescription</theory/fonll>`
+- applying the :doc:`scale variation prescription</theory/scalevar>`
+- burning the :doc:`K-factor</theory/kfactors>` into grids
+
 
 Checking the grids
 """"""""""""""""""
 
 Under the subcommand ``pineko check`` you can find two possible useful checks:
 
-1.  **compatibility**. This is used to check if a *grid* and an *eko* are compatible and ready to generate an Fk table. In order for a grid and an eko to be compatible, they must have the same x and Q2 grid (eventually including the factorization scale variations). The check is used as
-  ::
+1.  **compatibility**. This is used to check if a *grid* and an *eko* are compatible and ready to generate an |FK| table.
+    In order for a grid and an eko to be compatible, they must have the same x and Q2 grid (eventually including the
+    factorization scale variations). The check is used as
 
-    pineko check compatibility GRID EKO
+      pineko check compatibility GRID EKO
 
-  eventually specifying the value of the factorization scale variation with the option ``--xif``.
+    eventually specifying the value of the factorization scale variation with the option ``--xif``.
 2.  **scvar**. This is used to check if the provided grid contains the requested scale variations. The syntax is the following
-  ::
 
-    pineko check scvar GRID SCALE AS_ORDER AL_ORDER
+      pineko check scvar GRID SCALE AS_ORDER AL_ORDER
 
-  where ``SCALE`` can be one between "ren" and "fact" (respectively for *renormalization* and
-  *factorization* scale variations).
+    where ``SCALE`` can be one between "ren" and "fact" (respectively for *renormalization* and
+    *factorization* scale variations).
 
 Comparing grids and FK tables
 """""""""""""""""""""""""""""
 
 With the command ``pineko compare`` it is possible to compare the predictions as provided by the grid
-(convoluted with a |PDF|) with the predictions as provided by the FK table. This is done like::
+(convoluted with a |PDF|) with the predictions as provided by the |FK| table. This is done like
 
   pineko compare GRID FKTABLE MAX_AS MAX_AL PDF
 
 again eventually specifying the values of *renormalization* and *factorization* scales with the
 appropriate options.
-
-Scale variations
-""""""""""""""""
-
-Since it is possible to compute scale variations terms at a certain perturbative order N+1 just from
-the knowledge of the central N order (see https://pineko.readthedocs.io/en/latest/theory/scalevar.html),
-`pineko` includes a tool to add the required scale variations order to a grid which contain the
-necessary central orders. The command to run it is::
-
-  pineko ren_sv_grid GRID_PATH OUTPUT_FOLDER_PATH MAX_AS NF ORDER_EXISTS
-
-where ``GRID_PATH`` is the path of the original grid, ``OUTPUT_FOLDER_PATH`` is the folder where the
-updated grid will be dumped, ``MAX_AS`` is the requested perturbative order of the QCD coupling and
-``NF`` is the number of active flavors one wants to consider when computing the scale variations terms.
-If the original grid has already all the scale variations terms for the requested perturbative order,
-`pineko` will do nothing. If one want to force `pineko` to overwrite the already existing orders, it is
-enough to set ``ORDER_EXISTS`` to `True`.
-
-KFactors
-""""""""
-
-Another useful tool that `pineko` includes is ``pineko kfactor`` which allows the embedding of a kfactor
-as a proper order in a grid. The usage is the following::
-
-  pineko kfactor GRIDS_FOLDER KFACTOR_FOLDER YAMLDB_PATH TARGET_FOLDER MAX_AS ORDER_EXISTS
-
-where ``GRIDS_FOLDER`` is the folder containing the grids to update, ``KFACTOR_FOLDER`` is the folder
-containing the kfactor files and ``YAMLDB_PATH`` is the path to the yamldb file of the requested dataset.
-The other inputs have already been described in the previous section.
-
-Notes
------
-
-.. [5] examples being scale variations, different DIS settings, etc.

--- a/docs/source/overview/running.rst
+++ b/docs/source/overview/running.rst
@@ -92,13 +92,13 @@ The manual procedure works as follow:
 
   2. Generate the grids corresponding to all the 7 theories with the external program.
 
-  3. Generate the operator cards for each theory with the usual command.
+  3. Generate the operator cards for each theory with the normal command listed above.
      Note that, in principle, only 3 ekos are needed, as there are only 3 different :math:`n_f` patches.
      So you might speed up the procedure taking advantage of inherit-ekos.
 
-  4. Generate the ekos for each theory with the usual commands.
+  4. Generate the ekos for each theory with the normal command listed above.
 
-  5. Generate the FK tables each of the 7 theories with the usual commands.
+  5. Generate the FK tables each of the 7 theories with the normal command listed above.
 
   6. Combine the various FK tables into a single file, using the command::
 

--- a/docs/source/overview/running.rst
+++ b/docs/source/overview/running.rst
@@ -86,7 +86,7 @@ The manual procedure works as follow:
       * ``THEORY_ID05`` : massless component of |FFNS| :math:`n_f=5`
       * ``THEORY_ID06`` : massive component of |FFNS| :math:`n_f=5`
 
-    where for |FFNS| :math:`n_f=4,5` massive and massless parts are splitted to
+    where for |FFNS| :math:`n_f=4,5` massive and massless parts are split to
     allow for a damping option.
 
   2. Generate the grids corresponding to all the 7 theories with the external program.

--- a/docs/source/overview/running.rst
+++ b/docs/source/overview/running.rst
@@ -61,7 +61,7 @@ the options ``--xir`` and ``--xif``.
 Generating FONLL FK Tables
 --------------------------
 
-In order to generate FK tables with (numerical) |FONLL| the different flavor schemes
+In order to generate FK tables with |FONLL| the different flavor schemes
 need to be evolved separately and joined together in a single FK table only
 in the final step.
 

--- a/docs/source/overview/running.rst
+++ b/docs/source/overview/running.rst
@@ -118,7 +118,7 @@ In this case the workflows is:
 
   2. Generate the grids corresponding to all the 7 theories with the external program.
 
-  3. Generate the ekos for only 3 theories and inherit the others running::
+  3. Generate the three ekos, one for each :math:`n_f`, and inherit the others running:
 
       pineko fonll_ekos THEORY_ID DATASET1 DATASET2 ...
 

--- a/docs/source/overview/running.rst
+++ b/docs/source/overview/running.rst
@@ -30,7 +30,7 @@ This is a two step process:
 
 
 Inherit |EKO| or grids from Existing Theory
-"""""""""""""""""""""""""""""""""""
+"""""""""""""""""""""""""""""""""""""""""""
 
 You can reuse the |EKO| from a different theory by running::
 
@@ -62,69 +62,70 @@ Generating FONLL FK Tables
 --------------------------
 
 In order to generate FK tables with (numerical) |FONLL| the different flavor schemes
-need to be evolved separately and joined together in a single FK table only 
-in the final step. 
+need to be evolved separately and joined together in a single FK table only
+in the final step.
 
-There are 2 workflows possible, one in which all the steps are performed individually 
-and one that is more automatize. 
+There are 2 workflows possible, one in which all the steps are performed individually
+and one that is more automatize.
 
 The automatize workflows always assumes that |FONLL| is performed both for
 charm and bottom effects.
 
 The manual procedure works as follow:
 
-  1. Generate 7 theories for all the different flavor patches with command:
+  1. Generate 7 theories for all the different flavor patches with command::
 
       pineko fonll_tcards THEORY_ID
 
     The different flavor patches are named following the convention:
 
-      * THEORY_ID00 : |FFNS| :math:`n_f=3`
-      * THEORY_ID01 : |FFN0| :math:`n_f=3`
-      * THEORY_ID02 : massless component of |FFNS| :math:`n_f=4`
-      * THEORY_ID03 : massive component of |FFNS| :math:`n_f=4`
-      * THEORY_ID05 : massless component of |FFNS| :math:`n_f=5`
-      * THEORY_ID06 : massive component of |FFNS| :math:`n_f=5`
-    
+      * ``THEORY_ID00`` : |FFNS| :math:`n_f=3`
+      * ``THEORY_ID01`` : |FFN0| :math:`n_f=3`
+      * ``THEORY_ID02`` : massless component of |FFNS| :math:`n_f=4`
+      * ``THEORY_ID03`` : massive component of |FFNS| :math:`n_f=4`
+      * ``THEORY_ID05`` : massless component of |FFNS| :math:`n_f=5`
+      * ``THEORY_ID06`` : massive component of |FFNS| :math:`n_f=5`
+
     where for |FFNS| :math:`n_f=4,5` massive and massless parts are splitted to
     allow for a damping option.
 
   2. Generate the grids corrisponding to all the 7 theories with the external program.
-  
+
   3. Generate the operator cards for each theory with the usual command.
-  4. Generate the ekos for each theory with the usual commands.
-     Note that in principle only 3 ekos are needed, as there are only 3 different :math:`n_f` patches.
+     Note that, in principle, only 3 ekos are needed, as there are only 3 different :math:`n_f` patches.
      So you might speed up the procedure taking advantage of inherit-ekos.
-    
+
+  4. Generate the ekos for each theory with the usual commands.
+
   5. Generate the FK tables each of the 7 theories with the usual commands.
 
-  6. Combine the various FK tables into a single file, using the command:
+  6. Combine the various FK tables into a single file, using the command::
 
       pineko combine_fonll THEORY_ID DATASET --FFNS3 THEORY_ID00 --FFN03 THEORY_ID01 --FFNS4til THEORY_ID02 --FFNS4bar THEORY_ID03 --FFN04 THEORY_ID04 --FFNS5til THEORY_ID05 --FFNS5bar THEORY_ID06
 
-    where the first 3 theories are needed to perform |FONLL| on charm effects, 
+    where the first 3 theories are needed to perform |FONLL| on charm effects,
     while the last 4 are needed to include also bottom effects.
 
-The automatize procedure can be faster, but it might be less
-flexible. In this case the workflows is:
+The automatize procedure can be faster, but it might be less flexible.
+In this case the workflows is:
 
-  1. Generate 7 theories for all the different flavor patches with command:
+  1. Generate 7 theories for all the different flavor patches with the command::
 
       pineko fonll_tcards THEORY_ID
-    
-    See above for the naming convention
-  
+
+    See above for the intermediate theories naming convention.
+
   2. Generate the grids corrisponding to all the 7 theories with the external program.
 
-  3. Generate the ekos for only 3 theories and inherit the others using the command:
+  3. Generate the ekos for only 3 theories and inherit the others running::
 
       pineko fonll_ekos THEORY_ID DATASET1 DATASET2 ...
 
-    Note: this is usually an expensive operation as multiple ekos are run sequentially. 
+    Note: this is usually an expensive operation as multiple ekos are run sequentially.
     Depending on the resources that you have available it might be more convinient
     to call the command separately for each DATASET.
-  
-  4. Generate the final |FONLL| FK table directly using:
+
+  4. Generate the final |FONLL| FK table directly running::
 
       pineko fonll_fks THEORY_ID DATASET1 DATASET2 ...
 

--- a/docs/source/overview/running.rst
+++ b/docs/source/overview/running.rst
@@ -66,7 +66,7 @@ need to be evolved separately and joined together in a single FK table only
 in the final step.
 
 There are 2 workflows possible, one in which all the steps are performed individually
-and one that is more automatize.
+and one that is more automatized.
 
 The automatize workflows always assumes that |FONLL| is performed both for
 charm and bottom effects.

--- a/docs/source/overview/running.rst
+++ b/docs/source/overview/running.rst
@@ -29,13 +29,16 @@ This is a two step process:
 
 
 
-Inherit |EKO| from Existing Theory
+Inherit |EKO| or grids from Existing Theory
 """""""""""""""""""""""""""""""""""
 
 You can reuse the |EKO| from a different theory by running::
 
   pineko theory inherit-ekos SOURCE_THEORY_ID TARGET_THEORY_ID DATASET1 DATASET2 ...
 
+You can reuse the grid from a different theory by running::
+
+  pineko theory inherit-grids SOURCE_THEORY_ID TARGET_THEORY_ID DATASET1 DATASET2 ...
 
 The relation between the source theory and the target theory is non-trivial [5]_.
 
@@ -53,6 +56,78 @@ Note that you can also convolute a single grid with a single eko (obtaining a si
 
 If necessary it is possible to specify the values of the *renormalization* and *factorization* scale variations with
 the options ``--xir`` and ``--xif``.
+
+
+Generating FONLL FK Tables
+--------------------------
+
+In order to generate FK tables with (numerical) |FONLL| the different flavor schemes
+need to be evolved separately and joined together in a single FK table only 
+in the final step. 
+
+There are 2 workflows possible, one in which all the steps are performed individually 
+and one that is more automatize. 
+
+The automatize workflows always assumes that |FONLL| is performed both for
+charm and bottom effects.
+
+The manual procedure works as follow:
+
+  1. Generate 7 theories for all the different flavor patches with command:
+
+      pineko fonll_tcards THEORY_ID
+
+    The different flavor patches are named following the convention:
+
+      * THEORY_ID00 : |FFNS| :math:`n_f=3`
+      * THEORY_ID01 : |FFN0| :math:`n_f=3`
+      * THEORY_ID02 : massless component of |FFNS| :math:`n_f=4`
+      * THEORY_ID03 : massive component of |FFNS| :math:`n_f=4`
+      * THEORY_ID05 : massless component of |FFNS| :math:`n_f=5`
+      * THEORY_ID06 : massive component of |FFNS| :math:`n_f=5`
+    
+    where for |FFNS| :math:`n_f=4,5` massive and massless parts are splitted to
+    allow for a damping option.
+
+  2. Generate the grids corrisponding to all the 7 theories with the external program.
+  
+  3. Generate the operator cards for each theory with the usual command.
+  4. Generate the ekos for each theory with the usual commands.
+     Note that in principle only 3 ekos are needed, as there are only 3 different :math:`n_f` patches.
+     So you might speed up the procedure taking advantage of inherit-ekos.
+    
+  5. Generate the FK tables each of the 7 theories with the usual commands.
+
+  6. Combine the various FK tables into a single file, using the command:
+
+      pineko combine_fonll THEORY_ID DATASET --FFNS3 THEORY_ID00 --FFN03 THEORY_ID01 --FFNS4til THEORY_ID02 --FFNS4bar THEORY_ID03 --FFN04 THEORY_ID04 --FFNS5til THEORY_ID05 --FFNS5bar THEORY_ID06
+
+    where the first 3 theories are needed to perform |FONLL| on charm effects, 
+    while the last 4 are needed to include also bottom effects.
+
+The automatize procedure can be faster, but it might be less
+flexible. In this case the workflows is:
+
+  1. Generate 7 theories for all the different flavor patches with command:
+
+      pineko fonll_tcards THEORY_ID
+    
+    See above for the naming convention
+  
+  2. Generate the grids corrisponding to all the 7 theories with the external program.
+
+  3. Generate the ekos for only 3 theories and inherit the others using the command:
+
+      pineko fonll_ekos THEORY_ID DATASET1 DATASET2 ...
+
+    Note: this is usually an expensive operation as multiple ekos are run sequentially. 
+    Depending on the resources that you have available it might be more convinient
+    to call the command separately for each DATASET.
+  
+  4. Generate the final |FONLL| FK table directly using:
+
+      pineko fonll_fks THEORY_ID DATASET1 DATASET2 ...
+
 
 Other functionalities
 ---------------------

--- a/docs/source/overview/running.rst
+++ b/docs/source/overview/running.rst
@@ -89,7 +89,7 @@ The manual procedure works as follow:
     where for |FFNS| :math:`n_f=4,5` massive and massless parts are splitted to
     allow for a damping option.
 
-  2. Generate the grids corrisponding to all the 7 theories with the external program.
+  2. Generate the grids corresponding to all the 7 theories with the external program.
 
   3. Generate the operator cards for each theory with the usual command.
      Note that, in principle, only 3 ekos are needed, as there are only 3 different :math:`n_f` patches.

--- a/docs/source/overview/running.rst
+++ b/docs/source/overview/running.rst
@@ -106,7 +106,7 @@ The manual procedure works as follow:
     where the first 3 theories are needed to perform |FONLL| on charm effects,
     while the last 4 are needed to include also bottom effects.
 
-The automatize procedure can be faster, but it might be less flexible.
+The automatized procedure can be faster, but it might be less flexible.
 In this case the workflows is:
 
   1. Generate 7 theories for all the different flavor patches with the command::

--- a/docs/source/overview/running.rst
+++ b/docs/source/overview/running.rst
@@ -116,7 +116,7 @@ In this case the workflows is:
 
     See above for the intermediate theories naming convention.
 
-  2. Generate the grids corrisponding to all the 7 theories with the external program.
+  2. Generate the grids corresponding to all the 7 theories with the external program.
 
   3. Generate the ekos for only 3 theories and inherit the others running::
 

--- a/docs/source/overview/running.rst
+++ b/docs/source/overview/running.rst
@@ -79,12 +79,13 @@ The manual procedure works as follow:
 
     The different flavor patches are named following the convention:
 
-      * ``THEORY_ID00`` : |FFNS| :math:`n_f=3`
-      * ``THEORY_ID01`` : |FFN0| :math:`n_f=3`
-      * ``THEORY_ID02`` : massless component of |FFNS| :math:`n_f=4`
-      * ``THEORY_ID03`` : massive component of |FFNS| :math:`n_f=4`
-      * ``THEORY_ID05`` : massless component of |FFNS| :math:`n_f=5`
-      * ``THEORY_ID06`` : massive component of |FFNS| :math:`n_f=5`
+      * ``<THEORY_ID>00`` : |FFNS| :math:`n_f=3`
+      * ``<THEORY_ID>01`` : |FFN0| :math:`n_f=3`
+      * ``<THEORY_ID>02`` : massless component of |FFNS| :math:`n_f=4`
+      * ``<THEORY_ID>03`` : massive component of |FFNS| :math:`n_f=4`
+      * ``<THEORY_ID>04`` : |FFN0| :math:`n_f=4`
+      * ``<THEORY_ID>05`` : massless component of |FFNS| :math:`n_f=5`
+      * ``<THEORY_ID>06`` : massive component of |FFNS| :math:`n_f=5`
 
     where for |FFNS| :math:`n_f=4,5` massive and massless parts are split to
     allow for a damping option.

--- a/docs/source/shared/abbreviations.rst
+++ b/docs/source/shared/abbreviations.rst
@@ -11,8 +11,15 @@
 .. |FFNS| replace::
     :abbr:`FFNS (Fixed Flavor Number Scheme)`
 
+.. |FFN0| replace::
+    :abbr:`FFN0 (Asymptotic Fixed Flavor Number Scheme)`
+
 .. |VFNS| replace::
     :abbr:`VFNS (Variable Flavor Number Scheme)`
+
+.. |FONLL| replace::
+    :abbr:`FONLL (Fixed Order Next-to-Leading Log)`
+
 
 
 .. perturbative orders

--- a/docs/source/theory/fktables.rst
+++ b/docs/source/theory/fktables.rst
@@ -1,6 +1,6 @@
-============================================================
+
 Fast Kernel (FK) tables
-============================================================
+=======================
 
 The direct calculation of observables during a |PDF| fit is not very practical
 since it requires first solving the |DGLAP| evolution equation for each new boundary

--- a/docs/source/theory/fonll.rst
+++ b/docs/source/theory/fonll.rst
@@ -1,0 +1,74 @@
+FONLL
+=====
+
+In order to generate |FK| tables with |FONLL| the different flavor schemes
+need to be evolved separately and joined together in a single |FK| table only
+in the final step.
+
+There are 2 workflows possible, one in which all the steps are performed individually
+and one that is more automatized.
+
+The automatized workflows always assumes that |FONLL| is performed both for
+charm and bottom effects.
+
+Manual procedure
+----------------
+
+  1. Generate 7 theories for all the different flavor patches with command::
+
+      pineko fonll_tcards THEORY_ID
+
+    The different flavor patches are named following the convention:
+
+      * ``<THEORY_ID>00`` : |FFNS| :math:`n_f=3`
+      * ``<THEORY_ID>01`` : |FFN0| :math:`n_f=3`
+      * ``<THEORY_ID>02`` : massless component of |FFNS| :math:`n_f=4`
+      * ``<THEORY_ID>03`` : massive component of |FFNS| :math:`n_f=4`
+      * ``<THEORY_ID>04`` : |FFN0| :math:`n_f=4`
+      * ``<THEORY_ID>05`` : massless component of |FFNS| :math:`n_f=5`
+      * ``<THEORY_ID>06`` : massive component of |FFNS| :math:`n_f=5`
+
+    where for |FFNS| :math:`n_f=4,5` massive and massless parts are split to
+    allow for a damping option.
+
+  2. Generate the grids corresponding to all the 7 theories with the external program.
+
+  3. Generate the operator cards for each theory with the normal command listed above.
+     Note that, in principle, only 3 ekos are needed, as there are only 3 different :math:`n_f` patches.
+     So you might speed up the procedure taking advantage of inherit-ekos.
+
+  4. Generate the ekos for each theory with the normal command listed above.
+
+  5. Generate the |FK| tables each of the 7 theories with the normal command listed above.
+
+  6. Combine the various |FK| tables into a single file, using the command::
+
+      pineko combine_fonll THEORY_ID DATASET --FFNS3 THEORY_ID00 --FFN03 THEORY_ID01 --FFNS4til THEORY_ID02 --FFNS4bar THEORY_ID03 --FFN04 THEORY_ID04 --FFNS5til THEORY_ID05 --FFNS5bar THEORY_ID06
+
+    where the first 3 theories are needed to perform |FONLL| on charm effects,
+    while the last 4 are needed to include also bottom effects.
+
+Automatic procedure
+-------------------
+
+This workflow can be faster, but it might be less flexible:
+
+  1. Generate 7 theories for all the different flavor patches with the command::
+
+      pineko fonll_tcards THEORY_ID
+
+    See above for the intermediate theories naming convention.
+
+  2. Generate the grids corresponding to all the 7 theories with the external program.
+
+  3. Generate the three ekos, one for each :math:`n_f`, and inherit the others running::
+
+      pineko fonll_ekos THEORY_ID DATASET1 DATASET2 ...
+
+    Note: this is usually an expensive operation as multiple ekos are run sequentially.
+    Depending on the resources that you have available it might be more convenient
+    to call the command separately for each DATASET.
+
+  4. Generate the final |FONLL| |FK| table directly running::
+
+      pineko fonll_fks THEORY_ID DATASET1 DATASET2 ...

--- a/docs/source/theory/fonll.rst
+++ b/docs/source/theory/fonll.rst
@@ -16,7 +16,7 @@ Manual procedure
 
   1. Generate 7 theories for all the different flavor patches with command::
 
-      pineko fonll_tcards THEORY_ID
+      pineko fonll tcards THEORY_ID
 
     The different flavor patches are named following the convention:
 
@@ -43,7 +43,7 @@ Manual procedure
 
   6. Combine the various |FK| tables into a single file, using the command::
 
-      pineko combine_fonll THEORY_ID DATASET --FFNS3 THEORY_ID00 --FFN03 THEORY_ID01 --FFNS4til THEORY_ID02 --FFNS4bar THEORY_ID03 --FFN04 THEORY_ID04 --FFNS5til THEORY_ID05 --FFNS5bar THEORY_ID06
+      pineko fonll combine THEORY_ID DATASET --FFNS3 THEORY_ID00 --FFN03 THEORY_ID01 --FFNS4til THEORY_ID02 --FFNS4bar THEORY_ID03 --FFN04 THEORY_ID04 --FFNS5til THEORY_ID05 --FFNS5bar THEORY_ID06
 
     where the first 3 theories are needed to perform |FONLL| on charm effects,
     while the last 4 are needed to include also bottom effects.
@@ -55,7 +55,7 @@ This workflow can be faster, but it might be less flexible:
 
   1. Generate 7 theories for all the different flavor patches with the command::
 
-      pineko fonll_tcards THEORY_ID
+      pineko fonll tcards THEORY_ID
 
     See above for the intermediate theories naming convention.
 
@@ -63,7 +63,7 @@ This workflow can be faster, but it might be less flexible:
 
   3. Generate the three ekos, one for each :math:`n_f`, and inherit the others running::
 
-      pineko fonll_ekos THEORY_ID DATASET1 DATASET2 ...
+      pineko fonll ekos THEORY_ID DATASET1 DATASET2 ...
 
     Note: this is usually an expensive operation as multiple ekos are run sequentially.
     Depending on the resources that you have available it might be more convenient
@@ -71,4 +71,4 @@ This workflow can be faster, but it might be less flexible:
 
   4. Generate the final |FONLL| |FK| table directly running::
 
-      pineko fonll_fks THEORY_ID DATASET1 DATASET2 ...
+      pineko fonll fks THEORY_ID DATASET1 DATASET2 ...

--- a/docs/source/theory/fonll.rst
+++ b/docs/source/theory/fonll.rst
@@ -43,7 +43,7 @@ Manual procedure
 
   6. Combine the various |FK| tables into a single file, using the command::
 
-      pineko fonll combine THEORY_ID DATASET --FFNS3 THEORY_ID00 --FFN03 THEORY_ID01 --FFNS4til THEORY_ID02 --FFNS4bar THEORY_ID03 --FFN04 THEORY_ID04 --FFNS5til THEORY_ID05 --FFNS5bar THEORY_ID06
+      pineko fonll combine THEORY_ID DATASET --FFNS3 THEORY_ID00 --FFN03 THEORY_ID01 --FFNS4zeromass THEORY_ID02 --FFNS4massive THEORY_ID03 --FFN04 THEORY_ID04 --FFNS5zeromass THEORY_ID05 --FFNS5massive THEORY_ID06
 
     where the first 3 theories are needed to perform |FONLL| on charm effects,
     while the last 4 are needed to include also bottom effects.

--- a/docs/source/theory/kfactors.rst
+++ b/docs/source/theory/kfactors.rst
@@ -1,0 +1,11 @@
+K-Factors
+=========
+
+Another useful tool that `pineko` includes is ``pineko kfactor`` which allows the embedding of a kfactor
+as a proper order in a grid. The usage is the following::
+
+  pineko kfactor GRIDS_FOLDER KFACTOR_FOLDER YAMLDB_PATH TARGET_FOLDER MAX_AS ORDER_EXISTS
+
+where ``GRIDS_FOLDER`` is the folder containing the grids to update, ``KFACTOR_FOLDER`` is the folder
+containing the kfactor files and ``YAMLDB_PATH`` is the path to the yamldb file of the requested dataset.
+The other inputs have already been described in the previous section.

--- a/docs/source/theory/scalevar.rst
+++ b/docs/source/theory/scalevar.rst
@@ -117,7 +117,7 @@ where this time the perturbative expansion of :math:`\overline{H}(\alpha_{s}(t+\
 than :math:`\mathcal{O}(\alpha_{s}^{0})`.
 
 Scale variation for |PDF| evolution
-###########################################
+###################################
 
 A completely independent source of |MHOU| arises from the truncation of the perturbative expansion of the anomalous dimensions governing the evolution
 of the |PDF|. Again, this uncertainties can be estimated trough scale variation but, in this case, there are three equivalent ways in which it can be
@@ -222,3 +222,20 @@ Note that, even if these schemes are formally equivalent, they can differ by sub
 In fact, in **scheme A** some higher order terms of the anomalous dimensions expansion can be retained according to the kind of solution adopted for the evolution equation.
 In **scheme B** the exponential has been expanded so that it corresponds to a linearized solution of the evolution equations and in **scheme C** some terms coming from the
 cross-expansion of the coefficients functions and the linearized solution of the evolution equations have been dropped.
+
+
+Adding scale variations to a grid
+#################################
+
+Since it is possible to compute scale variations terms at a certain perturbative order N+1 just from
+the knowledge of the central N order, `pineko` includes a tool to add the required scale variations order to a grid which contain the
+necessary central orders. The command to run it is::
+
+  pineko ren_sv_grid GRID_PATH OUTPUT_FOLDER_PATH MAX_AS NF ORDER_EXISTS
+
+where ``GRID_PATH`` is the path of the original grid, ``OUTPUT_FOLDER_PATH`` is the folder where the
+updated grid will be dumped, ``MAX_AS`` is the requested perturbative order of the QCD coupling and
+``NF`` is the number of active flavors one wants to consider when computing the scale variations terms.
+If the original grid has already all the scale variations terms for the requested perturbative order,
+`pineko` will do nothing. If one want to force `pineko` to overwrite the already existing orders, it is
+enough to set ``ORDER_EXISTS`` to `True`.

--- a/src/pineko/cli/_base.py
+++ b/src/pineko/cli/_base.py
@@ -1,12 +1,18 @@
 """Adds global CLI options."""
 
 import pathlib
+import sys
 
 import click
 
 from .. import configs
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+
+
+def help_requested():
+    """Check if you are requesting help."""
+    return len(set(CONTEXT_SETTINGS["help_option_names"]) & set(sys.argv)) > 0
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
@@ -26,6 +32,9 @@ config_option = click.option(
 
 def load_config(cfg):
     """Load configuration files."""
+    # if just help is needed, return before loading
+    if help_requested():
+        return
     path = configs.detect(cfg)
     base_configs = configs.load(path)
     configs.configs = configs.defaults(base_configs)

--- a/src/pineko/cli/_base.py
+++ b/src/pineko/cli/_base.py
@@ -1,6 +1,10 @@
 """Adds global CLI options."""
 
+import pathlib
+
 import click
+
+from .. import configs
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
@@ -8,3 +12,22 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 @click.group(context_settings=CONTEXT_SETTINGS)
 def command():
     """pineko: Combine PineAPPL grids and EKOs into FK tables."""
+
+
+config_option = click.option(
+    "-c",
+    "--configs",
+    "cfg",
+    default=None,
+    type=click.Path(resolve_path=True, path_type=pathlib.Path),
+    help="Explicitly specify config file (it has to be a valid TOML file).",
+)
+
+
+def load_config(cfg):
+    """Load configuration files."""
+    path = configs.detect(cfg)
+    base_configs = configs.load(path)
+    configs.configs = configs.defaults(base_configs)
+    if cfg is not None:
+        print(f"Configurations loaded from '{path}'")

--- a/src/pineko/cli/_base.py
+++ b/src/pineko/cli/_base.py
@@ -32,7 +32,7 @@ config_option = click.option(
 
 def load_config(cfg):
     """Load configuration files."""
-    # if just help is needed, return before loading
+    # if only help is needed, return before loading
     if help_requested():
         return
     path = configs.detect(cfg)

--- a/src/pineko/cli/fonll.py
+++ b/src/pineko/cli/fonll.py
@@ -86,7 +86,7 @@ def fonll_tcards(theoryid, cfg):
         raise TheoryCardError("The theorycard does not correspond to an FONLL scheme.")
     fonll.dump_tcards(tcard, tcard_parent_path, theoryid)
 
-
+@command.command("fonll_ekos")
 @click.argument("theoryID", type=click.INT)
 @click.argument("datasets", type=click.STRING, nargs=-1)
 @click.option("--overwrite", is_flag=True, help="Allow files to be overwritten")
@@ -144,6 +144,7 @@ def fonll_ekos(theoryid, datasets, overwrite, cfg):
     )
 
 
+@command.command("fonll_fks")
 @click.argument("theoryID", type=click.INT)
 @click.argument("datasets", type=click.STRING, nargs=-1)
 @click.option("--pdf", "-p", default=None, help="PDF set used for comparison")

--- a/src/pineko/cli/fonll.py
+++ b/src/pineko/cli/fonll.py
@@ -1,15 +1,14 @@
 """CLI entry point to FONLL."""
 
-import logging
 import pathlib
 
 import click
+import rich
 
 from .. import configs, fonll, theory, theory_card
 from ..fonll import TheoryCardError
 from ._base import command
 
-logger = logging.getLogger(__name__)
 
 
 config_setting = click.option(
@@ -125,12 +124,12 @@ def fonll_ekos(theoryid, datasets, overwrite, cfg):
 
     # now inherit ekos
     # nf=3
-    logger.info("Inherit nf=3 from theory %i00", theoryid)
+    rich.print(f"[green] Inherit nf=3 ekos from theory {theoryid}00")
     theory.TheoryBuilder(f"{theoryid}00", datasets, overwrite=overwrite).inherit_ekos(
         f"{theoryid}01"
     )
     # nf=4
-    logger.info("Inherit nf=4 from theory %i04", theoryid)
+    rich.print(f"[green] Inherit nf=4 ekos from theory {theoryid}04")
     theory.TheoryBuilder(f"{theoryid}04", datasets, overwrite=overwrite).inherit_ekos(
         f"{theoryid}02"
     )
@@ -138,7 +137,7 @@ def fonll_ekos(theoryid, datasets, overwrite, cfg):
         f"{theoryid}03"
     )
     # nf=5
-    logger.info("Inherit nf=5 from theory %i05", theoryid)
+    rich.print(f"[green] Inherit nf=5 ekos from theory {theoryid}05")
     theory.TheoryBuilder(f"{theoryid}05", datasets, overwrite=overwrite).inherit_ekos(
         f"{theoryid}06"
     )

--- a/src/pineko/cli/fonll.py
+++ b/src/pineko/cli/fonll.py
@@ -9,8 +9,6 @@ from .. import configs, fonll, theory, theory_card
 from ..fonll import TheoryCardError
 from ._base import command
 
-
-
 config_setting = click.option(
     "-c",
     "--configs",
@@ -85,6 +83,7 @@ def fonll_tcards(theoryid, cfg):
         raise TheoryCardError("The theorycard does not correspond to an FONLL scheme.")
     fonll.dump_tcards(tcard, tcard_parent_path, theoryid)
 
+
 @command.command("fonll_ekos")
 @click.argument("theoryID", type=click.INT)
 @click.argument("datasets", type=click.STRING, nargs=-1)
@@ -93,19 +92,11 @@ def fonll_tcards(theoryid, cfg):
 def fonll_ekos(theoryid, datasets, overwrite, cfg):
     """Command to generate numerical FONLL ekos.
 
-    1. Produce the 7 theory cards needed for numerical FONLL.
-    2. Create the 3 operator cards for the different flavor patches.
-    3. Run the 3 ekos for the different flavor patches.
-    4. Inherit the ekos.
+    1. Create the 3 operator cards for the different flavor patches.
+    2. Run the 3 ekos for the different flavor patches.
+    3. Inherit the ekos.
     """
     load_config(cfg)
-
-    # create the 7 theory cards
-    tcard = theory_card.load(theoryid)
-    tcard_parent_path = theory_card.path(theoryid).parent
-    if "FONLL" not in tcard["FNS"]:
-        raise TheoryCardError("The theorycard does not correspond to an FONLL scheme.")
-    fonll.dump_tcards(tcard, tcard_parent_path, theoryid)
 
     for nf_id in ["00", "04", "05"]:
         # create opcards

--- a/src/pineko/cli/fonll.py
+++ b/src/pineko/cli/fonll.py
@@ -4,11 +4,10 @@ import logging
 import pathlib
 
 import click
-import rich
 
-from .. import configs, fonll, parser, theory, theory_card
+from .. import configs, fonll, theory, theory_card
+from ..fonll import TheoryCardError
 from ._base import command
-from .theory_ import theory_
 
 logger = logging.getLogger(__name__)
 
@@ -23,29 +22,13 @@ config_setting = click.option(
 )
 
 
-class TheoryCardError(Exception):
-    """Raised when asked for FONLL theory cards with an original tcard as input that is not asking for FONLL."""
-
-
-class InconsistentInputsError(Exception):
-    """Raised if the inputs are not consistent with FONLL."""
-
-
-def cfgpath(name, grid):
-    """Path of the fktable in 'name' called 'grid' if it exists, else None."""
-    path = configs.configs["paths"]["fktables"] / name / grid
-    return path if path.exists() else None
-
-
-def grids_names(yaml_file):
-    """Return the list of the grids in the yaml file."""
-    yaml_content = parser._load_yaml(yaml_file)
-    # Turn the operands and the members into paths (and check all of them exist)
-    ret = []
-    for operand in yaml_content["operands"]:
-        for member in operand:
-            ret.append(f"{member}.{parser.EXT}")
-    return ret
+def load_config(cfg):
+    """Iterate a subcommand on a given theory and list of datasets."""
+    path = configs.detect(cfg)
+    base_configs = configs.load(path)
+    configs.configs = configs.defaults(base_configs)
+    if cfg is not None:
+        print(f"Configurations loaded from '{path}'")
 
 
 @command.command("combine_fonll")
@@ -74,71 +57,20 @@ def subcommand(
     cfg,
 ):
     """Combine the different FKs needed to produce the FONLL prescription."""
-    path = configs.detect(cfg)
-    base_configs = configs.load(path)
-    configs.configs = configs.defaults(base_configs)
-    if cfg is not None:
-        print(f"Configurations loaded from '{path}'")
-
-    # Checks
-
-    if not ffns3 or not ffn03:
-        raise InconsistentInputsError("ffns3 and/or ffn03 is not provided.")
-
-    if ffns4til is None or ffns4bar is None:
-        raise InconsistentInputsError(
-            "At least one of ffns4til and ffns4bar should be provided."
-        )
-
-    # Do we consider two masses, i.e. mc and mb
-    if any([ffns5til, ffns5bar, ffn04]):
-        if (ffns5til is None and ffns5bar is None) or ffn04 is None:
-            raise InconsistentInputsError(
-                "To include nf5 contributions, ffn04 and at least one between ffns5til and ffns5bar are mandatory"
-            )
-
-    # Get theory info
-    tcard = theory_card.load(theoryid)
-    if tcard["DAMP"] == 1:
-        if not "DAMPPOWERc" in tcard or not "DAMPPOWERb" in tcard:
-            raise InconsistentInputsError(
-                "If DAMP is set, set also DAMPPOWERb and DAMPPOWERc"
-            )
-    else:
-        tcard["DAMPPOWERb"] = 0
-        tcard["DAMPPOWERc"] = 0
-    # Getting the paths to the grids
-    grids_name = grids_names(configs.configs["paths"]["ymldb"] / f"{dataset}.yaml")
-    for grid in grids_name:
-        # Checking if it already exists
-        new_fk_path = configs.configs["paths"]["fktables"] / str(theoryid) / grid
-        if new_fk_path.exists():
-            if not overwrite:
-                rich.print(
-                    f"[green]Success:[/] skipping existing FK Table {new_fk_path}"
-                )
-                return
-        fonll.produce_combined_fk(
-            *(
-                cfgpath(str(name), grid)
-                for name in (
-                    ffns3,
-                    ffn03,
-                    ffns4til,
-                    ffns4bar,
-                    ffn04,
-                    ffns5til,
-                    ffns5bar,
-                )
-            ),
-            theoryid,
-            damp=(tcard["DAMP"], tcard["DAMPPOWERc"], tcard["DAMPPOWERb"]),
-            cfg=cfg,
-        )
-        if new_fk_path.exists():
-            rich.print(f"[green]Success:[/] Wrote FK table to {new_fk_path}")
-        else:
-            rich.print(f"[red]Failure:[/]")
+    load_config(cfg)
+    fonll.assembly_combined_fk(
+        theoryid,
+        dataset,
+        ffns3,
+        ffn03,
+        ffns4til,
+        ffns4bar,
+        ffn04,
+        ffns5til,
+        ffns5bar,
+        overwrite,
+        cfg,
+    )
 
 
 @command.command("fonll_tcards")
@@ -146,9 +78,8 @@ def subcommand(
 @config_setting
 def fonll_tcards(theoryid, cfg):
     """Produce the FONLL tcards starting from the original tcard given by the theoryID."""
-    path = configs.detect(cfg)
-    base_configs = configs.load(path)
-    configs.configs = configs.defaults(base_configs)
+    load_config(cfg)
+
     tcard = theory_card.load(theoryid)
     tcard_parent_path = theory_card.path(theoryid).parent
     if "FONLL" not in tcard["FNS"]:
@@ -156,18 +87,19 @@ def fonll_tcards(theoryid, cfg):
     fonll.dump_tcards(tcard, tcard_parent_path, theoryid)
 
 
-@theory_.command()
 @click.argument("theoryID", type=click.INT)
 @click.argument("datasets", type=click.STRING, nargs=-1)
 @click.option("--overwrite", is_flag=True, help="Allow files to be overwritten")
-def fonll_ekos(theoryid, datasets, overwrite):
+@config_setting
+def fonll_ekos(theoryid, datasets, overwrite, cfg):
     """Command to generate numerical FONLL ekos.
 
-    1. Produce the 7 theory cards that are needed for numerical FONLL.
-    2. Creates the 3 opcards for the different flavor patches.
-    3. Runs the 3 ekos for the different flavor pathces.
+    1. Produce the 7 theory cards needed for numerical FONLL.
+    2. Create the 3 operator cards for the different flavor patches.
+    3. Run the 3 ekos for the different flavor patches.
     4. Inherit the ekos.
     """
+    load_config(cfg)
 
     # create the 7 theory cards
     tcard = theory_card.load(theoryid)
@@ -193,12 +125,12 @@ def fonll_ekos(theoryid, datasets, overwrite):
 
     # now inherit ekos
     # nf=3
-    logger.info(f"Inherit nf=3 from theory {theoryid}00")
+    logger.info("Inherit nf=3 from theory %i00", theoryid)
     theory.TheoryBuilder(f"{theoryid}00", datasets, overwrite=overwrite).inherit_ekos(
         f"{theoryid}01"
     )
     # nf=4
-    logger.info(f"Inherit nf=4 from theory {theoryid}04")
+    logger.info("Inherit nf=4 from theory %i04", theoryid)
     theory.TheoryBuilder(f"{theoryid}04", datasets, overwrite=overwrite).inherit_ekos(
         f"{theoryid}02"
     )
@@ -206,7 +138,47 @@ def fonll_ekos(theoryid, datasets, overwrite):
         f"{theoryid}03"
     )
     # nf=5
-    logger.info(f"Inherit nf=5 from theory {theoryid}05")
+    logger.info("Inherit nf=5 from theory %i05", theoryid)
     theory.TheoryBuilder(f"{theoryid}05", datasets, overwrite=overwrite).inherit_ekos(
         f"{theoryid}06"
     )
+
+
+@click.argument("theoryID", type=click.INT)
+@click.argument("datasets", type=click.STRING, nargs=-1)
+@click.option("--pdf", "-p", default=None, help="PDF set used for comparison")
+@click.option("--overwrite", is_flag=True, help="Allow files to be overwritten")
+@config_setting
+def fonll_fks(theoryid, datasets, pdf, overwrite, cfg):
+    """Command to generate numerical FONLL FK tables.
+
+    1. Produce the 7 FK tables needed for numerical FONLL.
+    2. Combine the FKtables into a single one.
+    """
+    load_config(cfg)
+
+    # create the 7 FK tables
+    for th_suffix in range(0, 7):
+        theory.TheoryBuilder(
+            f"{theoryid}0{th_suffix}",
+            datasets,
+            silent=False,
+            clear_logs=True,
+            overwrite=overwrite,
+        ).fks(pdf)
+
+    # combine
+    for dataset in datasets:
+        fonll.assembly_combined_fk(
+            theoryid,
+            dataset,
+            ffns3=f"{theoryid}00",
+            ffn03=f"{theoryid}01",
+            ffns4til=f"{theoryid}02",
+            ffns4bar=f"{theoryid}03",
+            ffn04=f"{theoryid}04",
+            ffns5til=f"{theoryid}05",
+            ffns5bar=f"{theoryid}06",
+            overwrite=overwrite,
+            cfg=cfg,
+        )

--- a/src/pineko/cli/fonll.py
+++ b/src/pineko/cli/fonll.py
@@ -20,22 +20,30 @@ def fonll_(cfg):
 @click.argument("dataset", type=str)
 @click.option("--FFNS3", type=int, help="theoryID containing the ffns3 fktable")
 @click.option("--FFN03", type=int, help="theoryID containing the ffn03 fktable")
-@click.option("--FFNS4til", type=int, help="theoryID containing the ffns4til fktable")
-@click.option("--FFNS4bar", type=int, help="theoryID containing the ffns4bar fktable")
+@click.option(
+    "--FFNS4zeromass", type=int, help="theoryID containing the ffns4 zeromass fktable"
+)
+@click.option(
+    "--FFNS4massive", type=int, help="theoryID containing the ffns4massive fktable"
+)
 @click.option("--FFN04", type=int, help="theoryID containing the ffn04 fktable")
-@click.option("--FFNS5til", type=int, help="theoryID containing the ffns5til fktable")
-@click.option("--FFNS5bar", type=int, help="theoryID containing the ffns5bar fktable")
+@click.option(
+    "--FFNS5zeromass", type=int, help="theoryID containing the ffns5 zeromass fktable"
+)
+@click.option(
+    "--FFNS5massive", type=int, help="theoryID containing the ffns5massive fktable"
+)
 @click.option("--overwrite", is_flag=True, help="Allow files to be overwritten")
 def combine(
     theoryid,
     dataset,
     ffns3,
     ffn03,
-    ffns4til,
-    ffns4bar,
+    ffns4zeromass,
+    ffns4massive,
     ffn04,
-    ffns5til,
-    ffns5bar,
+    ffns5zeromass,
+    ffns5massive,
     overwrite,
 ):
     """Combine the different FKs needed to produce the FONLL prescription."""
@@ -44,11 +52,11 @@ def combine(
         dataset,
         ffns3,
         ffn03,
-        ffns4til,
-        ffns4bar,
+        ffns4zeromass,
+        ffns4massive,
         ffn04,
-        ffns5til,
-        ffns5bar,
+        ffns5zeromass,
+        ffns5massive,
         overwrite,
     )
 
@@ -139,10 +147,10 @@ def fks(theoryid, datasets, pdf, overwrite):
             dataset,
             ffns3=f"{theoryid}00",
             ffn03=f"{theoryid}01",
-            ffns4til=f"{theoryid}02",
-            ffns4bar=f"{theoryid}03",
+            ffns4zeromass=f"{theoryid}02",
+            ffns4massive=f"{theoryid}03",
             ffn04=f"{theoryid}04",
-            ffns5til=f"{theoryid}05",
-            ffns5bar=f"{theoryid}06",
+            ffns5zeromass=f"{theoryid}05",
+            ffns5massive=f"{theoryid}06",
             overwrite=overwrite,
         )

--- a/src/pineko/cli/scaffold.py
+++ b/src/pineko/cli/scaffold.py
@@ -1,30 +1,17 @@
 """'scaffold' mode of CLI."""
 
-import pathlib
-
 import click
 import rich
 
 from .. import configs, scaffold
-from ._base import command
+from ._base import command, config_option, load_config
 
 
 @command.group("scaffold")
-@click.option(
-    "-c",
-    "--configs",
-    "cfg",
-    default=None,
-    type=click.Path(resolve_path=True, path_type=pathlib.Path),
-    help="Explicitly specify config file (it has to be a valid TOML file).",
-)
+@config_option
 def scaffold_(cfg):
-    """Manage folders needed for the project as spelled out in the configuration file."""
-    path = configs.detect(cfg)
-    base_configs = configs.load(path)
-    configs.configs = configs.defaults(base_configs)
-    if cfg is not None:
-        print(f"Configurations loaded from '{path}'")
+    """Detect amd load configuration file."""
+    load_config(cfg)
 
 
 @scaffold_.command()

--- a/src/pineko/cli/theory_.py
+++ b/src/pineko/cli/theory_.py
@@ -1,29 +1,16 @@
 """'theory' mode of CLI."""
 
-import pathlib
-
 import click
 
-from .. import configs, theory
-from ._base import command
+from .. import theory
+from ._base import command, config_option, load_config
 
 
 @command.group("theory")
-@click.option(
-    "-c",
-    "--configs",
-    "cfg",
-    default=None,
-    type=click.Path(resolve_path=True, path_type=pathlib.Path),
-    help="Explicitly specify config file (it has to be a valid TOML file).",
-)
+@config_option
 def theory_(cfg):
-    """Iterate a subcommand on a given theory and list of datasets."""
-    path = configs.detect(cfg)
-    base_configs = configs.load(path)
-    configs.configs = configs.defaults(base_configs)
-    if cfg is not None:
-        print(f"Configurations loaded from '{path}'")
+    """Detect amd load configuration file."""
+    load_config(cfg)
 
 
 @theory_.command()

--- a/src/pineko/fonll.py
+++ b/src/pineko/fonll.py
@@ -193,7 +193,6 @@ def assembly_combined_fk(
     ffns5til,
     ffns5bar,
     overwrite,
-    cfg,
 ):
     """Perform consistency checks and combine the FONLL FK tables into one single FK table."""
     # Checks
@@ -248,7 +247,6 @@ def assembly_combined_fk(
             ),
             theoryid,
             damp=(tcard["DAMP"], tcard["DAMPPOWERc"], tcard["DAMPPOWERb"]),
-            cfg=cfg,
         )
         if new_fk_path.exists():
             rich.print(f"[green]Success:[/] Wrote FK table to {new_fk_path}")
@@ -266,7 +264,6 @@ def produce_combined_fk(
     ffns5bar,
     theoryid,
     damp=(0, None, None),
-    cfg=None,
 ):
     """Combine the FONLL FK tables into one single FK table."""
     fonll_info = FONLLInfo(ffns3, ffn03, ffns4til, ffns4bar, ffn04, ffns5til, ffns5bar)
@@ -279,14 +276,11 @@ def produce_combined_fk(
     )
     combined_fk = combine(fk_dict, dampings=dampings)
     input_theorycard_path = (
-        Path(configs.load(configs.detect(cfg))["paths"]["theory_cards"])
-        / f"{theoryid}.yaml"
+        Path(configs.configs["paths"]["theory_cards"]) / f"{theoryid}.yaml"
     )
     update_fk_theorycard(combined_fk, input_theorycard_path)
     # save final FONLL fktable
-    fk_folder = Path(configs.load(configs.detect(cfg))["paths"]["fktables"]) / str(
-        theoryid
-    )
+    fk_folder = Path(configs.configs["paths"]["fktables"]) / str(theoryid)
     fk_folder.mkdir(exist_ok=True)
     output_path_fk = fk_folder / fonll_info.dataset_name
     combined_fk.write_lz4(output_path_fk)

--- a/src/pineko/fonll.py
+++ b/src/pineko/fonll.py
@@ -8,6 +8,7 @@ import tempfile
 from pathlib import Path
 
 import pineappl
+import rich
 import yaml
 
 from . import configs, parser, theory_card
@@ -228,8 +229,8 @@ def assembly_combined_fk(
         new_fk_path = configs.configs["paths"]["fktables"] / str(theoryid) / grid
         if new_fk_path.exists():
             if not overwrite:
-                logger.info(
-                    "[green]Success:[/] skipping existing FK Table %s", str(new_fk_path)
+                rich.print(
+                    f"[green]Success:[/] skipping existing FK Table {new_fk_path}"
                 )
                 return
         produce_combined_fk(
@@ -250,9 +251,9 @@ def assembly_combined_fk(
             cfg=cfg,
         )
         if new_fk_path.exists():
-            logger.info("[green]Success:[/] Wrote FK table to %s", str(new_fk_path))
+            rich.print(f"[green]Success:[/] Wrote FK table to {new_fk_path}")
         else:
-            logger.info("[red]Failure:[/]")
+            rich.print("[red]Failure:[/]")
 
 
 def produce_combined_fk(
@@ -362,5 +363,5 @@ def dump_tcards(tcard, tcard_parent_path, theoryid):
         with open(theorycard_path, "w", encoding="UTF-8") as f:
             yaml.safe_dump(theorycard, f)
         paths_list.append(theorycard_path)
-        logger.info("[green]Wrote theory card to %s", str(theorycard_path))
+        rich.print(f"[green]Wrote theory card to {theorycard_path}")
     return paths_list

--- a/src/pineko/fonll.py
+++ b/src/pineko/fonll.py
@@ -333,6 +333,7 @@ def collect_updates(fonll_fns):
                 "NfFF": cfg.nf,
                 "PTO": po,
                 "FONLLParts": cfg.parts,
+                "PTOEKO": int(base_pto),
             }
         )
         # In a mixed FONLL scheme we only subract the resummed terms that are

--- a/src/pineko/fonll.py
+++ b/src/pineko/fonll.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pineappl
 import yaml
 
-from . import configs, theory_card, parser
+from . import configs, parser, theory_card
 
 logger = logging.getLogger(__name__)
 

--- a/src/pineko/fonll.py
+++ b/src/pineko/fonll.py
@@ -29,8 +29,8 @@ MIXED_ORDER_FNS = ["FONLL-B", "FONLL-D"]
 """FONLL schemes with mixed orders."""
 # Notice we rely on the order defined by the FONLLInfo class
 FK_TO_DAMP = {
-    "mc": ["ffn03", "ffns4til", "ffn04", "ffns5til"],
-    "mb": ["ffn04", "ffns5til"],
+    "mc": ["ffn03", "ffns4zeromass", "ffn04", "ffns5zeromass"],
+    "mb": ["ffn04", "ffns5zeromass"],
 }
 FK_WITH_MINUS = ["ffn03", "ffn04"]  # asy terms should be subtracted, therefore the sign
 """FNS schemes to be subtracted during the FONLL procedure."""
@@ -48,17 +48,24 @@ class FONLLInfo:
     """Class containing all the information for FONLL predictions."""
 
     def __init__(
-        self, ffns3, ffn03, ffns4til, ffns4bar, ffn04, ffns5til, ffns5bar
+        self,
+        ffns3,
+        ffn03,
+        ffns4zeromass,
+        ffns4massive,
+        ffn04,
+        ffns5zeromass,
+        ffns5massive,
     ) -> None:
         """Initialize fonll info."""
         self.paths = {
             "ffns3": ffns3,
             "ffn03": ffn03,
-            "ffns4til": ffns4til,
-            "ffns4bar": ffns4bar,
+            "ffns4zeromass": ffns4zeromass,
+            "ffns4massive": ffns4massive,
             "ffn04": ffn04,
-            "ffns5til": ffns5til,
-            "ffns5bar": ffns5bar,
+            "ffns5zeromass": ffns5zeromass,
+            "ffns5massive": ffns5massive,
         }
         actually_existing_paths = [p for p, g in self.paths.items() if g is not None]
         for p in self.paths:
@@ -187,11 +194,11 @@ def assembly_combined_fk(
     dataset,
     ffns3,
     ffn03,
-    ffns4til,
-    ffns4bar,
+    ffns4zeromass,
+    ffns4massive,
     ffn04,
-    ffns5til,
-    ffns5bar,
+    ffns5zeromass,
+    ffns5massive,
     overwrite,
 ):
     """Perform consistency checks and combine the FONLL FK tables into one single FK table."""
@@ -199,16 +206,16 @@ def assembly_combined_fk(
     if not ffns3 or not ffn03:
         raise InconsistentInputsError("ffns3 and/or ffn03 is not provided.")
 
-    if ffns4til is None or ffns4bar is None:
+    if ffns4zeromass is None or ffns4massive is None:
         raise InconsistentInputsError(
-            "At least one of ffns4til and ffns4bar should be provided."
+            "At least one of ffns4 zeromass and ffns4 massive should be provided."
         )
 
     # Do we consider two masses, i.e. mc and mb
-    if any([ffns5til, ffns5bar, ffn04]):
-        if (ffns5til is None and ffns5bar is None) or ffn04 is None:
+    if any([ffns5zeromass, ffns5massive, ffn04]):
+        if (ffns5zeromass is None and ffns5massive is None) or ffn04 is None:
             raise InconsistentInputsError(
-                "To include nf5 contributions, ffn04 and at least one between ffns5til and ffns5bar are mandatory"
+                "To include nf5 contributions, ffn04 and at least one between ffns5 zeromass and ffns5 massive are mandatory"
             )
 
     # Get theory info
@@ -238,11 +245,11 @@ def assembly_combined_fk(
                 for name in (
                     ffns3,
                     ffn03,
-                    ffns4til,
-                    ffns4bar,
+                    ffns4zeromass,
+                    ffns4massive,
                     ffn04,
-                    ffns5til,
-                    ffns5bar,
+                    ffns5zeromass,
+                    ffns5massive,
                 )
             ),
             theoryid,
@@ -257,16 +264,18 @@ def assembly_combined_fk(
 def produce_combined_fk(
     ffns3,
     ffn03,
-    ffns4til,
-    ffns4bar,
+    ffns4zeromass,
+    ffns4massive,
     ffn04,
-    ffns5til,
-    ffns5bar,
+    ffns5zeromass,
+    ffns5massive,
     theoryid,
     damp=(0, None, None),
 ):
     """Combine the FONLL FK tables into one single FK table."""
-    fonll_info = FONLLInfo(ffns3, ffn03, ffns4til, ffns4bar, ffn04, ffns5til, ffns5bar)
+    fonll_info = FONLLInfo(
+        ffns3, ffn03, ffns4zeromass, ffns4massive, ffn04, ffns5zeromass, ffns5massive
+    )
     theorycard_constituent_fks = fonll_info.theorycard_no_fns_pto
     fk_dict = fonll_info.fks
     dampings = (

--- a/src/pineko/theory.py
+++ b/src/pineko/theory.py
@@ -317,6 +317,13 @@ class TheoryBuilder:
         )
         # setup data
         ocard = self.load_operator_card(name)
+        # For nFONLL mixed prescriptions (such as FONLL-B) the PTO written on
+        # the tcard is used to produce the grid by yadism and it might be different
+        # from the PTO needed for the PDF evolution (and so by EKO). Here we
+        # ensure that the PTO used in the EKO calculation reflects the real
+        # perturbative order of the prescription.
+        if "PTOEKO" in tcard:
+            tcard["PTO"] = tcard["PTOEKO"]
         # The operator card has been already generated in the correct format
         # The theory card needs to be converted to a format that eko can use
         legacy_class = eko.io.runcards.Legacy(tcard, ocard)

--- a/tests/test_fonll.py
+++ b/tests/test_fonll.py
@@ -29,11 +29,11 @@ def test_FONLLInfo():
     name_list = [
         "ffns3",
         "ffn03",
-        "ffns4til",
-        "ffns4bar",
+        "ffns4zeromass",
+        "ffns4massive",
         "ffn04",
-        "ffns5til",
-        "ffns5bar",
+        "ffns5zeromass",
+        "ffns5massive",
     ]
     assert fullfonll_fake_info.fk_paths == {
         name: pathlib.Path(fk) for name, fk in zip(name_list, full_list)


### PR DESCRIPTION
In this PR we try to automatise the procedure to generate numerical FONLL fk tables. 

- [x] We introduce 2 additional commands that will do the job, reusing the ekos where possible #130.
- [x] We add a documentation how to run numerical fonll. 
- [x] Fix `FONLL-B` bug.
- [x] Test and review.
- [ ] Expand documentation 
