### PR TITLE
Use json for theory card

### DIFF
--- a/src/pineko/fonll.py
+++ b/src/pineko/fonll.py
@@ -122,7 +122,7 @@ class FONLLInfo:
 def update_fk_theorycard(combined_fk, input_theorycard_path):
     """Update theorycard entries for the combined FK table.
 
-    Update by reading the yamldb of the original theory.
+    Update by reading the theory card of the original theory.
     """
     with open(input_theorycard_path, encoding="utf-8") as f:
         final_theorycard = yaml.safe_load(f)
@@ -132,7 +132,7 @@ def update_fk_theorycard(combined_fk, input_theorycard_path):
     theorycard["NfFF"] = final_theorycard["NfFF"]
     theorycard["ID"] = final_theorycard["ID"]
     # Update the theorycard with the entries set above
-    combined_fk.set_key_value("theory", str(theorycard))
+    combined_fk.set_key_value("theory", json.dumps(theorycard))
 
 
 def produce_dampings(theorycard_constituent_fks, fonll_info, damppowerc, damppowerb):

--- a/tests/test_fonll.py
+++ b/tests/test_fonll.py
@@ -1,4 +1,8 @@
+import copy
+import json
 import pathlib
+
+from banana.data.theories import default_card
 
 import pineko
 
@@ -50,3 +54,31 @@ def test_FONLLInfo():
         for name, fk in zip(name_list[:4], full_list[:4])
         if fk is not None
     }
+
+
+class FakeGrid:
+    kv: dict = {}
+
+    def key_values(self):
+        return self.kv
+
+    def set_key_value(self, k, v):
+        self.kv[k] = v
+
+
+def test_update_fk_theorycard(tmp_path):
+    # prepare base card
+    p = tmp_path / "blub.yaml"
+    base_tc = copy.deepcopy(default_card)
+    base_tc["PTO"] = 2
+    p.write_text(json.dumps(base_tc))
+    # fake grid
+    fg = FakeGrid()
+    fk_tc = copy.deepcopy(default_card)
+    fk_tc["PTO"] = 1
+    fg.set_key_value("theory", json.dumps(fk_tc))
+    # run the update
+    pineko.fonll.update_fk_theorycard(fg, p)
+    # check it actually worked
+    new_tc = json.loads(fg.key_values()["theory"])
+    assert new_tc["PTO"] == base_tc["PTO"]


### PR DESCRIPTION
As @alecandido [said](https://github.com/NNPDF/pineko/issues/164#issuecomment-2018766175) in #164, we should not use `str` to write the theory back to the grid but `json.dumps`. The present fix may or may not be the whole problem discussed in #164
