### PR TITLE
add nnpdf dependency to 'test' group

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -24,11 +24,11 @@ jobs:
           virtualenvs-create: false
           installer-parallel: true
       - name: Install dependencies
-        run: poetry install --no-interaction --no-root --with test -E nnpdf
+        run: poetry install --no-interaction --no-root --with test
       - name: Install project
         # it is required to repeat extras, otherwise they will be removed from
         # the environment
-        run: poetry install --no-interaction -E nnpdf
+        run: poetry install --no-interaction
       - name: Install task runner
         run: pip install poethepoet
       - name: Lint with pylint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ pandas = "^2.1"
 rich = "^12.5.1"
 click = "^8.0.4"
 tomli = "^2.0.1"
-nnpdf = { git = "https://github.com/NNPDF/nnpdf", optional = true}
 lhapdf-management = { version = "^0.5", optional = true }
 
 [tool.poetry.group.docs]
@@ -51,6 +50,7 @@ setuptools = "^69.0"
 optional = true
 
 [tool.poetry.group.test.dependencies]
+nnpdf = { git = "https://github.com/NNPDF/nnpdf" } # needed for test_utils
 pytest = "^7.1.3"
 pytest-cov = "^4.0.0"
 pytest-env = "^0.6.2"


### PR DESCRIPTION
To avoid pytest from failing we need nnpdf to be downloaded as part of the pypi upload workflow: https://github.com/NNPDF/workflows/blob/v2/.github/workflows/python-poetry-pypi.yml

Changing that workflow makes it less general, while adding nnpdf to 'test' dependencies doesn't look very nice, but making non-optional is perhaps also overkill (or we can skip the failing test_utils.py test of the nnpdf_data package). What is the preferred solution?
