### PR TITLE
Updating eko version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ packages = [{ include = "pineko", from = "src" }]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"
-eko = "^0.14.2"
+eko = "^0.14.4"
 pineappl = "^0.8.2"
 PyYAML = "^6.0"
 numpy = "^1.21.0"


### PR DESCRIPTION
While producing the EKOs for ATLAS_PH_8TEV_XSEC with eko version 0.14.3 I got the following error message related to multiprocessing, see attached. Once I moved to version 0.14.6 the problem disappeared. Therefore, as a solution, this PR modifies the pyproject.toml file to impose > 0.14.3.

[708-ATLAS_PH_8TEV_XSEC.txt](https://github.com/user-attachments/files/18675191/708-ATLAS_PH_8TEV_XSEC.txt)
