### PR TITLE
Completely remove `grid.optimize()`

### DIFF
--- a/src/pineko/cli/check.py
+++ b/src/pineko/cli/check.py
@@ -38,7 +38,6 @@ def sub_compatibility(grid_path, operator_path, xif, max_as, max_al):
 
     """
     pineappl_grid = pineappl.grid.Grid.read(grid_path)
-    pineappl_grid.optimize()
     with eko.EKO.read(pathlib.Path(operator_path)) as operators:
         for (q2, _), _ in operators.items():
             try:
@@ -88,7 +87,6 @@ SCVAR_MESSAGES = {
 def sub_scvar(grid_path, scale, max_as_order, max_al_order):
     """Check if PineAPPL grid contains requested scale variations for the requested order."""
     grid = pineappl.grid.Grid.read(grid_path)
-    grid.optimize()
 
     # Call the function
     scaleobj = check.Scale[scale]

--- a/src/pineko/cli/convolve.py
+++ b/src/pineko/cli/convolve.py
@@ -73,7 +73,6 @@ def subcommand(
     The PDFs are passed as strings with the names separated by commas.
     """
     grid = pineappl.grid.Grid.read(grid_path)
-    grid.optimize()
     n_ekos = len(op_paths)
     tcard = theory_card.load(theoryid)
     with eko.EKO.edit(pathlib.Path(op_paths[0])) as first_operator:

--- a/src/pineko/evolve.py
+++ b/src/pineko/evolve.py
@@ -123,7 +123,6 @@ def write_operator_card_from_file(
     if not pathlib.Path(pineappl_path).exists():
         raise FileNotFoundError(pineappl_path)
     pineappl_grid = pineappl.grid.Grid.read(pineappl_path)
-    pineappl_grid.optimize()
     default_card = yaml.safe_load(
         pathlib.Path(default_card_path).read_text(encoding="utf-8")
     )

--- a/src/pineko/theory.py
+++ b/src/pineko/theory.py
@@ -468,7 +468,6 @@ class TheoryBuilder:
         # loading grid
         grid = pineappl.grid.Grid.read(grid_path)
         # remove zero subgrid
-        grid.optimize()
 
         # Do you need one or multiple ekos?
         names = get_eko_names(grid_path, name, filter=False)


### PR DESCRIPTION
This reflects https://github.com/NNPDF/yadism/pull/365. Here, however, the changes have more significant impacts because they also affect the hadronic grids (if not pre-optimized by the MC generators) which are the main bottleneck when it comes to EKO computations.